### PR TITLE
✨ feat(settings): add new settings for summarySize, maxTokenSize, templateFormat, and dateFormat, along with reset button

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -117,7 +117,7 @@ class SettingTab extends PluginSettingTab {
 		new Setting(containerEl)
 			.setName("Template format")
 			.setDesc(
-				"Enter format of template to be used when inserting summary.  Supported fields are {{Date}}, {{Title}}, {{ImageURL}}, {{Description}}, and {{PodcastURL}}.",
+				"Enter format of template to be used when inserting summary.  Supported fields are {{Date}}, {{Title}}, {{ImageURL}}, {{Description}}, and {{VideoUrl}}.",
 			)
 			.addTextArea((text) => 
 				text

--- a/main.ts
+++ b/main.ts
@@ -8,17 +8,10 @@ import {
 	Setting,
 } from "obsidian";
 import { YoutubeVideoSummaryModal } from "src/Modals/YoutubeVideoSummaryModal";
-
-interface PluginSettings {
-	openAIApiKey: string;
-}
-
-const DEFAULT_SETTINGS: PluginSettings = {
-	openAIApiKey: "",
-};
+import { PluginSettings, DEFAULT_SETTINGS, DEFAULT_TEMPLATE, DEFAULT_SUMMARY_SIZE, MAX_SUMMARY_SIZE, MAX_TOKEN_SIZE_IN_A_REQUEST, DEFAULT_DATE_FORMAT } from "settings";
 
 export default class MyPlugin extends Plugin {
-	settings: PluginSettings;
+	public settings: PluginSettings;
 
 	async onload() {
 		await this.loadSettings();
@@ -37,7 +30,7 @@ export default class MyPlugin extends Plugin {
 					new YoutubeVideoSummaryModal(
 						this.app,
 						editor,
-						this.settings.openAIApiKey,
+						this.settings,
 					).open();
 				}
 			},
@@ -51,13 +44,17 @@ export default class MyPlugin extends Plugin {
 
 	async loadSettings() {
 		this.settings = Object.assign(
-			{},
-			DEFAULT_SETTINGS,
-			await this.loadData(),
+			Object.assign(DEFAULT_SETTINGS, (await this.loadData()) ?? {})
 		);
 	}
 
 	async saveSettings() {
+		await this.saveData(this.settings);
+	}
+
+	/** Update plugin settings. */
+	async updateSettings(settings: Partial<PluginSettings>) {
+		Object.assign(this.settings, settings);
 		await this.saveData(this.settings);
 	}
 }
@@ -85,9 +82,81 @@ class SettingTab extends PluginSettingTab {
 					.setPlaceholder("Enter your API key")
 					.setValue(this.plugin.settings.openAIApiKey)
 					.onChange(async (value) => {
-						this.plugin.settings.openAIApiKey = value;
-						await this.plugin.saveSettings();
+						await this.plugin.updateSettings({openAIApiKey: value});
 					}),
 			);
+		new Setting(containerEl)
+			.setName("Minimum Summary Size")
+			.setDesc("Minimum number key points to include in generated summary.")
+			.addText((text) =>
+				text
+					.setPlaceholder("3")
+					.setValue("" + this.plugin.settings.summarySize)
+					.onChange(async (value) => {
+						let parsed = parseInt(value);
+						if (isNaN(parsed)) return;
+						parsed = parsed > MAX_SUMMARY_SIZE ? MAX_SUMMARY_SIZE : 
+								 parsed < DEFAULT_SUMMARY_SIZE ? DEFAULT_SUMMARY_SIZE : parsed;
+						await this.plugin.updateSettings({summarySize: parsed});
+					})
+			);
+		new Setting(containerEl)
+			.setName("Maximum Token Size")
+			.setDesc("Maximum size of token in a given request to OpenAI.")
+			.addText((text) =>
+				text
+					.setPlaceholder("2500")
+					.setValue("" + this.plugin.settings.maxTokenSize)
+					.onChange(async (value) => {
+						let parsed = parseInt(value);
+						if (isNaN(parsed)) return;
+						parsed = parsed > MAX_TOKEN_SIZE_IN_A_REQUEST ? MAX_TOKEN_SIZE_IN_A_REQUEST : parsed;
+						await this.plugin.updateSettings({maxTokenSize: parsed});
+					})
+			);
+		new Setting(containerEl)
+			.setName("Template format")
+			.setDesc(
+				"Enter format of template to be used when inserting summary.  Supported fields are {{Date}}, {{Title}}, {{ImageURL}}, {{Description}}, and {{PodcastURL}}.",
+			)
+			.addTextArea((text) => 
+				text
+					.setPlaceholder(DEFAULT_TEMPLATE)
+					.setValue(this.plugin.settings.templateFormat)
+					.onChange(async (value) => {
+						await this.plugin.updateSettings({templateFormat: value});
+					}),
+			);
+		new Setting(containerEl)
+			.setName("Date format")
+            .setDesc("The default date format.")
+			.addTextArea((text) => 
+				text
+					.setPlaceholder(DEFAULT_DATE_FORMAT)
+					.setValue(this.plugin.settings.dateFormat)
+					.onChange(async (value) => {
+						await this.plugin.updateSettings({dateFormat: value});
+					}),
+			);
+		new Setting(containerEl)
+			.setName("Reset defaults")
+			.setDesc(
+				`This will reset to the default settings (without removing your API key).
+				The settings panel will be closed after pressing.
+				`
+				)
+			.addButton((cb) => {
+			  cb.setWarning()
+				.setButtonText("Reset defaults")
+				.onClick(() => {
+					this.plugin.settings.summarySize = DEFAULT_SUMMARY_SIZE;
+					this.plugin.settings.maxTokenSize = MAX_TOKEN_SIZE_IN_A_REQUEST;
+					this.plugin.settings.templateFormat = DEFAULT_TEMPLATE;
+					this.plugin.settings.dateFormat = DEFAULT_DATE_FORMAT;
+				  	this.plugin.saveSettings();
+					this.plugin.unload();
+					this.plugin.load();
+				});
+			});
 	}
 }

--- a/main.ts
+++ b/main.ts
@@ -87,7 +87,7 @@ class SettingTab extends PluginSettingTab {
 			);
 		new Setting(containerEl)
 			.setName("Minimum Summary Size")
-			.setDesc("Minimum number key points to include in generated summary.")
+			.setDesc("Minimum number of key points per video chunk to include in the generated summary. Note: The plugin divides long videos into chunks, extracts key points from each, and then combines them for the final summary.")
 			.addText((text) =>
 				text
 					.setPlaceholder("3")

--- a/main.ts
+++ b/main.ts
@@ -101,20 +101,6 @@ class SettingTab extends PluginSettingTab {
 					})
 			);
 		new Setting(containerEl)
-			.setName("Maximum Token Size")
-			.setDesc("Maximum size of token in a given request to OpenAI.")
-			.addText((text) =>
-				text
-					.setPlaceholder("2500")
-					.setValue("" + this.plugin.settings.maxTokenSize)
-					.onChange(async (value) => {
-						let parsed = parseInt(value);
-						if (isNaN(parsed)) return;
-						parsed = parsed > MAX_TOKEN_SIZE_IN_A_REQUEST ? MAX_TOKEN_SIZE_IN_A_REQUEST : parsed;
-						await this.plugin.updateSettings({maxTokenSize: parsed});
-					})
-			);
-		new Setting(containerEl)
 			.setName("Template format")
 			.setDesc(
 				"Enter format of template to be used when inserting summary.  Supported fields are {{Date}}, {{Title}}, {{ImageURL}}, {{Description}}, and {{VideoUrl}}.",
@@ -150,7 +136,6 @@ class SettingTab extends PluginSettingTab {
 				.setButtonText("Reset defaults")
 				.onClick(() => {
 					this.plugin.settings.summarySize = DEFAULT_SUMMARY_SIZE;
-					this.plugin.settings.maxTokenSize = MAX_TOKEN_SIZE_IN_A_REQUEST;
 					this.plugin.settings.templateFormat = DEFAULT_TEMPLATE;
 					this.plugin.settings.dateFormat = DEFAULT_DATE_FORMAT;
 				  	this.plugin.saveSettings();

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "youtube-summarizer",
 	"name": "Youtube Summarizer",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"minAppVersion": "0.15.0",
 	"description": "A plugin to summarize the transcripts of Youtube videos.",
 	"author": "Mehmet Ozdemir",

--- a/settings.ts
+++ b/settings.ts
@@ -4,29 +4,52 @@ export const DEFAULT_TEMPLATE = "---\ndate: {{Date}}\n---\n# {{Title}}\n![]({{Im
 export const DEFAULT_DATE_FORMAT = "YYYY-MM-DD";
 export const DEFAULT_SUMMARY_SIZE = 3;
 export const MAX_SUMMARY_SIZE = 20;
-export const MAX_TOKEN_SIZE_IN_A_REQUEST = 2500;
+export const OPEN_AI_MODEL_CHOICES = ["gpt-3.5-turbo","gpt-4","gpt-4-0125-preview","gpt-4-turbo-preview","gpt-4-1106-preview","gpt-4-vision-preview","gpt-4-0613","gpt-4-32k","gpt-4-32k-0613","gpt-3.5-turbo-1106","gpt-3.5-turbo-16k","gpt-3.5-turbo-instruct","gpt-3.5-turbo-0613","gpt-3.5-turbo-16k-0613","gpt-3.5-turbo-0301"];
+export const OPEN_AI_MODELS_MAX_TOKEN_SIZES = {
+	"gpt-3.5-turbo": 4096,
+	"gpt-4": 8192,
+	"gpt-4-0125-preview": 128000,
+	"gpt-4-turbo-preview": 128000,
+	"gpt-4-1106-preview": 128000,
+	"gpt-4-vision-preview": 128000,
+	"gpt-4-0613": 8192,
+	"gpt-4-32k": 32768,
+	"gpt-4-32k-0613": 32768,
+	"gpt-3.5-turbo-1106": 16385,
+	"gpt-3.5-turbo-16k": 16384,
+	"gpt-3.5-turbo-instruct": 4096,
+	"gpt-3.5-turbo-0613": 4096,
+	"gpt-3.5-turbo-16k-0613": 16384,
+	"gpt-3.5-turbo-0301": 4096
+};
+export const DEFAULT_MODEL = OPEN_AI_MODEL_CHOICES[0];
+export const DEFAULT_TOKEN_SIZE = OPEN_AI_MODELS_MAX_TOKEN_SIZES[DEFAULT_MODEL as keyof typeof OPEN_AI_MODELS_MAX_TOKEN_SIZES];
 
 export interface PluginSettings {
-	/** Open API Key */
+	/** Open AI Key */
 	openAIApiKey: string;
-	
+
+	/** Open AI Model */
+	openAIModel: string;
+
+	/** Max Token Size in a Request */
+	maxTokenSize: number;
+
 	/** Minimum Summary Lines */
 	summarySize: number;
 
-    /** Max Token Size in a Request */
-    maxTokenSize: number;
-	
 	/** Template Format */
 	templateFormat: string;
-	
-    /** Date Format */
+
+	/** Date Format */
 	dateFormat: string;
 }
 
 export const DEFAULT_SETTINGS: PluginSettings = {
-    openAIApiKey: "",
+	openAIApiKey: "",
+	openAIModel: DEFAULT_MODEL,
+	maxTokenSize: DEFAULT_TOKEN_SIZE,
 	summarySize: DEFAULT_SUMMARY_SIZE,
-    maxTokenSize: MAX_TOKEN_SIZE_IN_A_REQUEST,
 	templateFormat: DEFAULT_TEMPLATE,
 	dateFormat: DEFAULT_DATE_FORMAT
 };

--- a/settings.ts
+++ b/settings.ts
@@ -1,6 +1,6 @@
 /** Constants */
 export const YOUTUBE_BASE_URL = "youtube.com";
-export const DEFAULT_TEMPLATE = "---\ndate: {{Date}}\n---\n# {{Title}}\n![]({{ImageURL}})\n## Description:\n{{Description}}\n-> [Youtube video Link]({{PodcastURL}})\n\n## Summary:\n";
+export const DEFAULT_TEMPLATE = "---\ndate: {{Date}}\n---\n# {{Title}}\n![]({{ImageURL}})\n## Description:\n{{Description}}\n-> [Youtube video Link]({{VideoUrl}})\n\n## Summary:\n";
 export const DEFAULT_DATE_FORMAT = "YYYY-MM-DD";
 export const DEFAULT_SUMMARY_SIZE = 3;
 export const MAX_SUMMARY_SIZE = 20;

--- a/settings.ts
+++ b/settings.ts
@@ -1,0 +1,32 @@
+/** Constants */
+export const YOUTUBE_BASE_URL = "youtube.com";
+export const DEFAULT_TEMPLATE = "---\ndate: {{Date}}\n---\n# {{Title}}\n![]({{ImageURL}})\n## Description:\n{{Description}}\n-> [Youtube video Link]({{PodcastURL}})\n\n## Summary:\n";
+export const DEFAULT_DATE_FORMAT = "YYYY-MM-DD";
+export const DEFAULT_SUMMARY_SIZE = 3;
+export const MAX_SUMMARY_SIZE = 20;
+export const MAX_TOKEN_SIZE_IN_A_REQUEST = 2500;
+
+export interface PluginSettings {
+	/** Open API Key */
+	openAIApiKey: string;
+	
+	/** Minimum Summary Lines */
+	summarySize: number;
+
+    /** Max Token Size in a Request */
+    maxTokenSize: number;
+	
+	/** Template Format */
+	templateFormat: string;
+	
+    /** Date Format */
+	dateFormat: string;
+}
+
+export const DEFAULT_SETTINGS: PluginSettings = {
+    openAIApiKey: "",
+	summarySize: DEFAULT_SUMMARY_SIZE,
+    maxTokenSize: MAX_TOKEN_SIZE_IN_A_REQUEST,
+	templateFormat: DEFAULT_TEMPLATE,
+	dateFormat: DEFAULT_DATE_FORMAT
+};

--- a/src/Modals/YoutubeVideoSummaryModal.ts
+++ b/src/Modals/YoutubeVideoSummaryModal.ts
@@ -13,7 +13,7 @@ export class YoutubeVideoSummaryModal extends Modal {
 		super(app);
 		this.settings = settings;
 		this.editor = editor;
-		this.openAiClient = new OpenAIClient(this.settings.openAIApiKey);
+		this.openAiClient = new OpenAIClient(this.settings);
 		this.transcriptSummarizer = new TranscriptSummarizer(this.openAiClient, this.settings);
 	}
 

--- a/src/OpenAi/OpenAiClient.ts
+++ b/src/OpenAi/OpenAiClient.ts
@@ -1,20 +1,25 @@
 import OpenAI from "openai";
+import { PluginSettings } from "settings";
 
 export class OpenAIClient {
 
 	openai: OpenAI;
+	model: string;
 
-	constructor(apiKey: string) {
+	constructor(settings: PluginSettings) {
+		this.model = settings.openAIModel;
 		this.openai = new OpenAI({
-			apiKey: apiKey,
+			apiKey: settings.openAIApiKey,
 			dangerouslyAllowBrowser: true
 		})
 	}
  
 	async query(content: string): Promise<string> {
+		console.debug("Querying OpenAI with content: ", content);
+		console.debug("Model: ", this.model);
 		const chatCompletion = await this.openai.chat.completions.create({
 			messages: [{ role: 'assistant', content: content }],
-			model: 'gpt-3.5-turbo',
+			model: this.model,
 		});
 
 		return chatCompletion.choices.at(0)?.message.content!;

--- a/src/TranscriptSummarizer.ts
+++ b/src/TranscriptSummarizer.ts
@@ -1,7 +1,7 @@
 import { YoutubeTranscript } from "youtube-transcript";
 import { OpenAIClient } from "./OpenAi/OpenAiClient";
 import { YoutubeMetadataParser } from "./YoutubeMetadataParser/YoutubeVideoMetadataParser";
-import { PluginSettings, MAX_TOKEN_SIZE_IN_A_REQUEST } from "settings";
+import { PluginSettings } from "settings";
 
 export class TranscriptSummarizer {
 	constructor(private openAiClient: OpenAIClient, private settings: PluginSettings) { }
@@ -24,9 +24,9 @@ export class TranscriptSummarizer {
 		// Split the transcript into smaller pieces if necessary.
 		while (startIndex < words.length - 1) {
 			const endIndex =
-				startIndex + MAX_TOKEN_SIZE_IN_A_REQUEST > words.length
+				startIndex + this.settings.maxTokenSize > words.length
 					? words.length - 1
-					: startIndex + MAX_TOKEN_SIZE_IN_A_REQUEST;
+					: startIndex + this.settings.maxTokenSize;
 			const transcriptChunk = words.slice(startIndex, endIndex).join(" ");
 			startIndex = endIndex;
 

--- a/src/YoutubeMetadataParser/YoutubeVideoMetadataParser.ts
+++ b/src/YoutubeMetadataParser/YoutubeVideoMetadataParser.ts
@@ -37,7 +37,7 @@ export class YoutubeMetadataParser {
 			.replace(/{{Description}}/g, video.desc)
 			.replace(/{{Date}}/g, video.date)
 			.replace(/{{Timestamp}}/g, Date.now().toString())
-			.replace(/{{PodcastURL}}/g, video.url)
+			.replace(/{{VideoUrl}}/g, video.url)
 			.replace(/{{ShowNotes}}/g, video.showNotes)
 			.replace(/{{EpisodeDate}}/g, video.episodeDate);
 		console.debug("updated content", content);

--- a/src/YoutubeMetadataParser/YoutubeVideoMetadataParser.ts
+++ b/src/YoutubeMetadataParser/YoutubeVideoMetadataParser.ts
@@ -1,12 +1,11 @@
 import { DEFAULT_VIDEO } from "./Constants";
 import { Notice, moment, request } from "obsidian";
 import { YoutubeVideo, YoutubeVideoContent } from "./Models";
-
-const YOUTUBE_BASE_URL = "youtube.com";
-const TEMPLATE =
-	"---\ndate: {{Date}}\n---\n# {{Title}}\n![]({{ImageURL}})\n## Description:\n{{Description}}\n-> [Youtube video Link]({{PodcastURL}})\n\n## Summary:\n";
+import { PluginSettings, YOUTUBE_BASE_URL } from "settings";
 
 export class YoutubeMetadataParser {
+	constructor(private settings: PluginSettings) { }
+
 	async requestHTML(url: string) {
 		try {
 			let response = await request({ url: url, method: "GET" });
@@ -31,7 +30,9 @@ export class YoutubeMetadataParser {
 
 	applyTemplate(video: YoutubeVideo): YoutubeVideoContent {
 		video = this.sanitizePodcast(video);
-		let content = TEMPLATE.replace(/{{Title}}/g, video.title)
+		console.debug("template format", this.settings.templateFormat);
+		let content = this.settings.templateFormat
+			.replace(/{{Title}}/g, video.title)
 			.replace(/{{ImageURL}}/g, video.imageLink)
 			.replace(/{{Description}}/g, video.desc)
 			.replace(/{{Date}}/g, video.date)
@@ -39,6 +40,7 @@ export class YoutubeMetadataParser {
 			.replace(/{{PodcastURL}}/g, video.url)
 			.replace(/{{ShowNotes}}/g, video.showNotes)
 			.replace(/{{EpisodeDate}}/g, video.episodeDate);
+		console.debug("updated content", content);
 		return { title: video.title, content: content };
 	}
 


### PR DESCRIPTION
# Changes
- added settings.ts with default values populated
- moved interface and defaults to settings.ts
- added updatedSettings method to be able to save individual settings independently
- imported settings across all files, and passed settings into each via constructor
- added debug log statements for testing
- updated URL input to handle both full URL and IDs, e.g. `https://www.youtube.com/watch?v=nC7rpDXa4B8` and `nC7rpDXa4B8`
- bumped manifest version to 1.0.3

# References:
- https://github.com/obsidianmd/obsidian-sample-plugin/tree/master
- https://github.com/blacksmithgu/obsidian-dataview/tree/master/src
- https://github.com/coddingtonbear/obsidian-local-rest-api/tree/main/src

# Testing
## Settings pane with default values
![image](https://github.com/ozdemir08/youtube-video-summarizer/assets/750874/b2045177-bba0-4b45-a2c0-80961ae5ca19)

## Settings pane with modified values
![image](https://github.com/ozdemir08/youtube-video-summarizer/assets/750874/b54b22cf-3ebf-4b2e-bc70-5f925043335b)

## Generated content with default settings
![image](https://github.com/ozdemir08/youtube-video-summarizer/assets/750874/9903d22a-2661-4d7c-baee-aef12720b375)

## Generated content with updated template and summarySize
![image](https://github.com/ozdemir08/youtube-video-summarizer/assets/750874/7304fec2-2d89-4737-abcc-1b8d7847e3f7)
